### PR TITLE
Add observability providers

### DIFF
--- a/config/sus.rb
+++ b/config/sus.rb
@@ -5,3 +5,6 @@
 
 require "covered/sus"
 include Covered::Sus
+
+ENV["METRICS_BACKEND"] ||= "metrics/backend/test"
+ENV["TRACES_BACKEND"] ||= "traces/backend/test"

--- a/lib/async/service/supervisor/utilization_monitor.rb
+++ b/lib/async/service/supervisor/utilization_monitor.rb
@@ -277,10 +277,10 @@ module Async
 					:utilization_monitor
 				end
 				
-				# Serialize utilization data for JSON.
+				# Sample aggregated utilization data.
 				#
 				# @returns [Hash] Hash mapping service names to aggregated utilization metrics.
-				def as_json
+				def sample
 					@guard.synchronize do
 						aggregated = {}
 						
@@ -311,6 +311,13 @@ module Async
 						
 						aggregated
 					end
+				end
+				
+				# Serialize utilization data for JSON.
+				#
+				# @returns [Hash] Hash mapping service names to aggregated utilization metrics.
+				def as_json
+					self.sample
 				end
 				
 				# Emit the utilization metrics.

--- a/lib/metrics/provider/async/service/supervisor.rb
+++ b/lib/metrics/provider/async/service/supervisor.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require_relative "supervisor/process_monitor"
+require_relative "supervisor/utilization_monitor"

--- a/lib/metrics/provider/async/service/supervisor/process_monitor.rb
+++ b/lib/metrics/provider/async/service/supervisor/process_monitor.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "metrics/provider"
+
+require_relative "../../../../../async/service/supervisor/process_monitor"
+
+class Async::Service::Supervisor::ProcessMonitor
+	Metrics::Provider(self) do
+		PROCESS_METRICS_GENERAL_PROCESSOR_UTILIZATION = Metrics.metric("process.metrics.general.processor_utilization", :gauge, description: "Processor utilization for a supervised process.")
+		PROCESS_METRICS_GENERAL_TOTAL_SIZE = Metrics.metric("process.metrics.general.total_size", :gauge, description: "Total memory size for a supervised process.", unit: "bytes")
+		PROCESS_METRICS_GENERAL_VIRTUAL_SIZE = Metrics.metric("process.metrics.general.virtual_size", :gauge, description: "Virtual memory size for a supervised process.", unit: "bytes")
+		PROCESS_METRICS_GENERAL_RESIDENT_SIZE = Metrics.metric("process.metrics.general.resident_size", :gauge, description: "Resident memory size for a supervised process.", unit: "bytes")
+		
+		def emit(metrics)
+			metrics.each_value do |general|
+				if value = general[:processor_utilization]
+					PROCESS_METRICS_GENERAL_PROCESSOR_UTILIZATION.emit(value)
+				end
+				
+				if value = general[:total_size]
+					PROCESS_METRICS_GENERAL_TOTAL_SIZE.emit(value)
+				end
+				
+				if value = general[:virtual_size]
+					PROCESS_METRICS_GENERAL_VIRTUAL_SIZE.emit(value)
+				end
+				
+				if value = general[:resident_size]
+					PROCESS_METRICS_GENERAL_RESIDENT_SIZE.emit(value)
+				end
+			end
+			
+			super
+		end
+	end
+end

--- a/lib/metrics/provider/async/service/supervisor/utilization_monitor.rb
+++ b/lib/metrics/provider/async/service/supervisor/utilization_monitor.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "metrics/provider"
+require "metrics/tags"
+
+require_relative "../../../../../async/service/supervisor/utilization_monitor"
+
+class Async::Service::Supervisor::UtilizationMonitor
+	Metrics::Provider(self) do
+		UTILIZATION = Metrics.metric("async.utilization", :gauge, description: "Active requests per worker.")
+		UTILIZATION_CONNECTIONS_ACTIVE = Metrics.metric("async.utilization.connections.active", :gauge, description: "The number of active connections.")
+		UTILIZATION_CONNECTIONS_TOTAL = Metrics.metric("async.utilization.connections.total", :gauge, description: "The total number of connections.")
+		UTILIZATION_REQUESTS_ACTIVE = Metrics.metric("async.utilization.requests.active", :gauge, description: "The number of active requests.")
+		UTILIZATION_REQUESTS_TOTAL = Metrics.metric("async.utilization.requests.total", :gauge, description: "The total number of requests.")
+		UTILIZATION_WORKERS = Metrics.metric("async.utilization.workers", :gauge, description: "The number of workers contributing utilization metrics.")
+		
+		def emit(metrics)
+			metrics.each do |service_name, fields|
+				tags = Metrics::Tags.normalize(service: service_name)
+				
+				if connections_active = fields[:connections_active]
+					UTILIZATION_CONNECTIONS_ACTIVE.emit(connections_active, tags: tags)
+				end
+				
+				if connections_total = fields[:connections_total]
+					UTILIZATION_CONNECTIONS_TOTAL.emit(connections_total, tags: tags)
+				end
+				
+				if requests_active = fields[:requests_active]
+					UTILIZATION_REQUESTS_ACTIVE.emit(requests_active, tags: tags)
+				end
+				
+				if requests_total = fields[:requests_total]
+					UTILIZATION_REQUESTS_TOTAL.emit(requests_total, tags: tags)
+				end
+				
+				if worker_count = fields[:worker_count]
+					UTILIZATION_WORKERS.emit(worker_count, tags: tags)
+					
+					if worker_count > 0 and requests_active = fields[:requests_active]
+						UTILIZATION.emit(requests_active.to_f / worker_count, tags: tags)
+					end
+				end
+			end
+			
+			super
+		end
+	end
+end

--- a/lib/traces/provider/async/service/supervisor.rb
+++ b/lib/traces/provider/async/service/supervisor.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require_relative "supervisor/server"
+require_relative "supervisor/supervisor_controller"

--- a/lib/traces/provider/async/service/supervisor/server.rb
+++ b/lib/traces/provider/async/service/supervisor/server.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "traces/provider"
+
+require_relative "../../../../../async/service/supervisor/server"
+
+Traces::Provider(Async::Service::Supervisor::Server) do
+	def remove(controller)
+		return super unless controller.id
+		
+		attributes = {
+			"worker.id" => controller.id,
+			"worker.process_id" => controller.process_id,
+			"service.name" => controller.state[:name],
+			"monitor.count" => @monitors.size,
+		}
+		
+		Traces.trace("async.service.supervisor.worker.remove", attributes: attributes) do
+			super
+		end
+	end
+end

--- a/lib/traces/provider/async/service/supervisor/supervisor_controller.rb
+++ b/lib/traces/provider/async/service/supervisor/supervisor_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "traces/provider"
+
+require_relative "../../../../../async/service/supervisor/supervisor_controller"
+
+Traces::Provider(Async::Service::Supervisor::SupervisorController) do
+	def register(worker, process_id:, state: {})
+		attributes = {
+			"worker.process_id" => process_id,
+			"service.name" => state[:name],
+			"monitor.count" => @server.monitors.size,
+		}
+		
+		Traces.trace("async.service.supervisor.worker.register", attributes: attributes) do |span|
+			super.tap do |id|
+				span["worker.id"] = id
+			end
+		end
+	end
+end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Add opt-in `metrics` and `traces` providers for supervisor process metrics, utilization metrics, and worker lifecycle tracing.
+
 ## v0.16.0
 
   - Add `ProcessMonitor#emit(metrics)` as an override point for subclasses to consume captured process metrics (e.g. emitting StatsD gauges).

--- a/test/async/service/utilization_monitor.rb
+++ b/test/async/service/utilization_monitor.rb
@@ -127,6 +127,21 @@ describe Async::Service::Supervisor::UtilizationMonitor do
 		)
 	end
 	
+	it "can sample utilization data" do
+		monitor.register(supervisor_controller)
+		
+		worker_registry.metric(:connections_total).set(100)
+		worker_registry.metric(:connections_active).set(5)
+		
+		expect(monitor.sample).to have_keys(
+			"test_service" => have_keys(
+				connections_total: be == 100,
+				connections_active: be == 5,
+				worker_count: be == 1
+			)
+		)
+	end
+	
 	it "aggregates metrics from multiple workers" do
 		# Create second worker
 		registry2 = Async::Utilization::Registry.new

--- a/test/metrics/provider/async/service/supervisor.rb
+++ b/test/metrics/provider/async/service/supervisor.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "metrics"
+require "metrics/provider/async/service/supervisor"
+
+require "async/service/supervisor/process_monitor"
+require "async/service/supervisor/utilization_monitor"
+
+describe "metrics/provider/async/service/supervisor" do
+	def metric(owner, name)
+		owner.const_get(name, false)
+	end
+	
+	it "scopes metric constants to the instrumented classes" do
+		expect(Object.const_defined?(:PROCESS_METRICS_GENERAL_PROCESSOR_UTILIZATION, false)).to be == false
+		expect(Object.const_defined?(:UTILIZATION, false)).to be == false
+		expect(Object.const_defined?(:UTILIZATION_WORKERS, false)).to be == false
+		
+		expect(Async::Service::Supervisor::ProcessMonitor.const_defined?(:PROCESS_METRICS_GENERAL_PROCESSOR_UTILIZATION, false)).to be == true
+		expect(Async::Service::Supervisor::UtilizationMonitor.const_defined?(:UTILIZATION, false)).to be == true
+		expect(Async::Service::Supervisor::UtilizationMonitor.const_defined?(:UTILIZATION_WORKERS, false)).to be == true
+	end
+	
+	it "defines process monitor metrics" do
+		metric = metric(Async::Service::Supervisor::ProcessMonitor, :PROCESS_METRICS_GENERAL_PROCESSOR_UTILIZATION)
+		
+		expect(metric.name).to be == "process.metrics.general.processor_utilization"
+		expect(metric.type).to be == :gauge
+	end
+	
+	it "emits process monitor metrics" do
+		monitor = Async::Service::Supervisor::ProcessMonitor.new
+		
+		expect(metric(Async::Service::Supervisor::ProcessMonitor, :PROCESS_METRICS_GENERAL_PROCESSOR_UTILIZATION)).to receive(:emit).with(10.5).once
+		expect(metric(Async::Service::Supervisor::ProcessMonitor, :PROCESS_METRICS_GENERAL_TOTAL_SIZE)).to receive(:emit).with(2048).once
+		expect(metric(Async::Service::Supervisor::ProcessMonitor, :PROCESS_METRICS_GENERAL_VIRTUAL_SIZE)).to receive(:emit).with(4096).once
+		expect(metric(Async::Service::Supervisor::ProcessMonitor, :PROCESS_METRICS_GENERAL_RESIDENT_SIZE)).to receive(:emit).with(1024).once
+		
+		monitor.emit(
+			1234 => {
+				process_id: 1234,
+				parent_process_id: 12,
+				process_group_id: 34,
+				processor_utilization: 10.5,
+				total_size: 2048,
+				virtual_size: 4096,
+				resident_size: 1024,
+			}
+		)
+	end
+	
+	it "defines utilization monitor metrics" do
+		metric = metric(Async::Service::Supervisor::UtilizationMonitor, :UTILIZATION)
+		
+		expect(metric.name).to be == "async.utilization"
+		expect(metric.type).to be == :gauge
+	end
+	
+	it "emits utilization monitor metrics" do
+		monitor = Async::Service::Supervisor::UtilizationMonitor.allocate
+		tags = Metrics::Tags.normalize(service: "test_service")
+		
+		expect(metric(Async::Service::Supervisor::UtilizationMonitor, :UTILIZATION_CONNECTIONS_ACTIVE)).to receive(:emit).with(4, tags: tags).once
+		expect(metric(Async::Service::Supervisor::UtilizationMonitor, :UTILIZATION_CONNECTIONS_TOTAL)).to receive(:emit).with(10, tags: tags).once
+		expect(metric(Async::Service::Supervisor::UtilizationMonitor, :UTILIZATION_REQUESTS_ACTIVE)).to receive(:emit).with(2, tags: tags).once
+		expect(metric(Async::Service::Supervisor::UtilizationMonitor, :UTILIZATION_REQUESTS_TOTAL)).to receive(:emit).with(6, tags: tags).once
+		expect(metric(Async::Service::Supervisor::UtilizationMonitor, :UTILIZATION_WORKERS)).to receive(:emit).with(2, tags: tags).once
+		expect(metric(Async::Service::Supervisor::UtilizationMonitor, :UTILIZATION)).to receive(:emit).with(1.0, tags: tags).once
+		
+		monitor.emit(
+			"test_service" => {
+				connections_active: 4,
+				connections_total: 10,
+				requests_active: 2,
+				requests_total: 6,
+				unknown_depth: 7,
+				worker_count: 2,
+			}
+		)
+	end
+end

--- a/test/traces/provider/async/service/supervisor.rb
+++ b/test/traces/provider/async/service/supervisor.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "traces"
+require "traces/provider/async/service/supervisor"
+
+require "async/service/supervisor/server"
+require "async/service/supervisor/supervisor_controller"
+
+describe "traces/provider/async/service/supervisor" do
+	def server
+		Async::Service::Supervisor::Server.new(endpoint: IO::Endpoint.unix("test.ipc"))
+	end
+	
+	it "traces worker registration" do
+		server = self.server
+		connection = Object.new
+		controller = Async::Service::Supervisor::SupervisorController.new(server, connection)
+		worker = Object.new
+		
+		expect(Traces).to receive(:trace).with(
+			"async.service.supervisor.worker.register",
+			attributes: {
+				"worker.process_id" => 1234,
+				"service.name" => "test_service",
+				"monitor.count" => 0,
+			}
+		)
+		
+		id = controller.register(worker, process_id: 1234, state: {name: "test_service"})
+		
+		expect(id).to be == 1
+	end
+	
+	it "traces worker removal" do
+		server = self.server
+		connection = Object.new
+		controller = Async::Service::Supervisor::SupervisorController.new(server, connection)
+		worker = Object.new
+		
+		controller.register(worker, process_id: 1234, state: {name: "test_service"})
+		
+		expect(Traces).to receive(:trace).with(
+			"async.service.supervisor.worker.remove",
+			attributes: {
+				"worker.id" => 1,
+				"worker.process_id" => 1234,
+				"service.name" => "test_service",
+				"monitor.count" => 0,
+			}
+		)
+		
+		server.remove(controller)
+		
+		expect(server.controllers).to be(:empty?)
+	end
+end


### PR DESCRIPTION
## Summary
- add opt-in metrics providers for process and utilization monitors
- add opt-in traces providers for worker registration/removal lifecycle events
- expose utilization snapshots via `snapshot` and `snapshot_for`

## Testing
- `bundle exec rubocop`
- `bundle exec sus`