### PR TITLE
Allow explicit supervised worker state

### DIFF
--- a/lib/async/service/supervisor/supervised.rb
+++ b/lib/async/service/supervisor/supervised.rb
@@ -56,12 +56,13 @@ module Async
 				end
 				
 				# The supervised worker for the current process.
+				# @parameter state [Hash] The state to register with the supervisor.
 				# @returns [Worker] The worker client.
-				def supervisor_worker
+				def supervisor_worker(state: self.supervisor_worker_state)
 					Worker.new(
 						process_id: Process.pid,
 						endpoint: supervisor_endpoint,
-						state: self.supervisor_worker_state,
+						state: state,
 						utilization_schema: self.utilization_schema,
 						utilization_registry: self.utilization_registry,
 					)
@@ -70,11 +71,12 @@ module Async
 				# Create a supervised worker for the given instance.
 				#
 				# @parameter instance [Async::Container::Instance] The container instance.
+				# @parameter state [Hash] The state to register with the supervisor.
 				# @returns [Worker] The worker client.
-				def prepare!(instance)
+				def prepare!(instance, state: self.supervisor_worker_state)
 					super(instance)
 					
-					supervisor_worker.run
+					supervisor_worker(state: state).run
 				end
 			end
 		end

--- a/lib/async/service/supervisor/supervised.rb
+++ b/lib/async/service/supervisor/supervised.rb
@@ -56,9 +56,11 @@ module Async
 				end
 				
 				# The supervised worker for the current process.
-				# @parameter state [Hash] The state to register with the supervisor.
+				# @parameter state [Hash | Nil] Additional state to register with the supervisor.
 				# @returns [Worker] The worker client.
-				def supervisor_worker(state: self.supervisor_worker_state)
+				def supervisor_worker(state: nil)
+					state = self.supervisor_worker_state.merge(state || {})
+					
 					Worker.new(
 						process_id: Process.pid,
 						endpoint: supervisor_endpoint,
@@ -71,9 +73,9 @@ module Async
 				# Create a supervised worker for the given instance.
 				#
 				# @parameter instance [Async::Container::Instance] The container instance.
-				# @parameter state [Hash] The state to register with the supervisor.
+				# @parameter state [Hash | Nil] Additional state to register with the supervisor.
 				# @returns [Worker] The worker client.
-				def prepare!(instance, state: self.supervisor_worker_state)
+				def prepare!(instance, state: nil)
 					super(instance)
 					
 					supervisor_worker(state: state).run

--- a/releases.md
+++ b/releases.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-  - Allow supervised services to supply explicit worker state during preparation and worker construction.
+  - Allow supervised services to merge additional worker state during preparation and worker construction.
 
 ## v0.17.0
 

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Allow supervised services to supply explicit worker state during preparation and worker construction.
+
 ## v0.17.0
 
   - Add opt-in `metrics` and `traces` providers for supervisor process metrics, utilization metrics, and worker lifecycle tracing.

--- a/test/async/service/supervised.rb
+++ b/test/async/service/supervised.rb
@@ -56,5 +56,26 @@ describe Async::Service::Supervisor::Supervised do
 	ensure
 		worker_task&.stop
 	end
+	
+	it "can register explicit worker state" do
+		environment = Async::Service::Environment.build(root: @root) do
+			name "simple-service"
+			
+			service_class {SimpleService}
+			
+			include Async::Service::Supervisor::Supervised
+		end
+		
+		state = {
+			name: "simple-service",
+			endpoint: {name: "http", addresses: [{address: "127.0.0.1", port: 9292}]},
+		}
+		worker = environment.evaluator.supervisor_worker(state: state)
+		worker_task = worker.run
+		
+		event = registration_monitor.pop
+		expect(event.supervisor_controller.state).to be == state
+	ensure
+		worker_task&.stop
+	end
 end
-

--- a/test/async/service/supervised.rb
+++ b/test/async/service/supervised.rb
@@ -66,15 +66,17 @@ describe Async::Service::Supervisor::Supervised do
 			include Async::Service::Supervisor::Supervised
 		end
 		
-		state = {
-			name: "simple-service",
+		additional_state = {
 			endpoint: {name: "http", addresses: [{address: "127.0.0.1", port: 9292}]},
 		}
-		worker = environment.evaluator.supervisor_worker(state: state)
+		worker = environment.evaluator.supervisor_worker(state: additional_state)
 		worker_task = worker.run
 		
 		event = registration_monitor.pop
-		expect(event.supervisor_controller.state).to be == state
+		expect(event.supervisor_controller.state).to be == {
+			name: "simple-service",
+			endpoint: additional_state[:endpoint],
+		}
 	ensure
 		worker_task&.stop
 	end


### PR DESCRIPTION
## Summary

- Allow `supervisor_worker` and `prepare!` to receive explicit worker state.
- Preserve the existing lazily evaluated state as the default.
- Cover registration of caller-supplied runtime state.

This provides the runtime-state handoff needed by post-bind integrations such as socketry/async-service-supervisor-envoy#1 and socketry/falcon#356.

## Testing

- `bundle exec bake test` (61 tests, 180 assertions)
- `bundle exec rubocop`
- `bundle exec bake decode:index:coverage lib` (98/98 definitions)