### PR TITLE
Add observability provider test dependencies

### DIFF
--- a/gems.rb
+++ b/gems.rb
@@ -34,4 +34,7 @@ group :test do
 	
 	gem "bake-test"
 	gem "bake-test-external"
+	
+	gem "metrics"
+	gem "traces"
 end


### PR DESCRIPTION
The metrics and traces provider tests require their respective integration gems directly, but they were not included in the test bundle. This caused the test files to fail during loading in CI.

Add `metrics` and `traces` to the end of the test dependency group.

Validation:
- `bundle exec sus test/metrics/provider/async/service/supervisor.rb test/traces/provider/async/service/supervisor.rb`
- `bundle exec rubocop gems.rb`
- `bundle exec bake test`